### PR TITLE
Remove Gitter references

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@
 [![Github](https://img.shields.io/badge/source-github-orange)](https://github.com/oliver-zehentleitner/python-simplemachinesforum)
 [![Donations/week](http://img.shields.io/liberapay/receives/oliver-zehentleitner.svg?logo=liberapay)](https://liberapay.com/oliver-zehentleitner/donate)
 [![Patrons](http://img.shields.io/liberapay/patrons/oliver-zehentleitner.svg?logo=liberapay")](https://liberapay.com/oliver-zehentleitner/donate)
-[![Gitter](https://badges.gitter.im/python-simplemachinesforum/community.svg)](https://gitter.im/python-simplemachinesforum/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 # python-simplemachinesforum
 Python request API to Simple Machines Forum: https://www.simplemachines.org/

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ setuptools.setup(
          'Author': 'https://about.me/oliver-zehentleitner/',
          'Changes': 'https://github.com/oliver-zehentleitner/python-simplemachinesforum/blob/master/CHANGELOG.md',
          'Issue Tracker': 'https://github.com/oliver-zehentleitner/python-simplemachinesforum/issues',
-         'Chat': 'https://gitter.im/python-simplemachinesforum/community',
          'Get Support': 'https://www.lucit.tech/get-support.html',
      },
      packages=setuptools.find_packages(),


### PR DESCRIPTION
## Summary
- Remove Gitter badge from `README.md`
- Remove Gitter chat link from `setup.py` project_urls (Gitter service is dead)

## Test plan
- [ ] Verify the badge line is removed and README renders correctly
- [ ] Verify setup.py project_urls no longer contains Gitter link